### PR TITLE
Webpack - sourcemap devtool change

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,9 @@
     "ecmaVersion": 2020,
     "project": ["./tsconfig.eslint.json"]
   },
+  "ignorePatterns": [
+    "webpack.config.cjs"
+  ],  
   "rules": {
     "import/named": "error"
   }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 dist/svg
 dist/index.html
 dist/path.js
+dist/main.css.map
+dist/main.js.map
 /dist/path.js
 /dev.html
 /validate-json.js

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,5 @@
-// https://stackoverflow.com/questions/64721803/csp-error-while-serving-with-express-with-helmet-an-app-created-with-create-re
-// import cors from 'cors';
-// import helmet from 'helmet';
+import cors from 'cors';
+import helmet from 'helmet';
 
 import express, { Request, Response } from 'express';
 import path from 'path';
@@ -20,8 +19,8 @@ const appIndex = path.join(distDirPath, 'index.html');
  * App Config
  */
 
-// app.use(helmet());
-// app.use(cors());
+app.use(cors());
+app.use(helmet());
 
 // Parse requests as application/json:
 app.use(express.json());

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,5 @@
     "src/**/*.ts",
     "src/**/*.js",
     "server.ts",
-  ]
+  ],
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -51,6 +51,6 @@ module.exports = {
     }),
     new webpack.EnvironmentPlugin(['NODE_ENV']),
   ],
-  devtool: 'eval-source-map',
+  devtool: 'cheap-module-source-map',
   mode: process.env.NODE_ENV,
 };


### PR DESCRIPTION
- What: Changes sourcemap output type: https://webpack.js.org/configuration/devtool/
- Why: eval version was causing problems with CSP (helmet, cors) in server.ts